### PR TITLE
Fix typo in flex-direction declaration

### DIFF
--- a/web/css/compiled/login.css
+++ b/web/css/compiled/login.css
@@ -13,7 +13,7 @@ html,body{
     html,body{
         background-color:#33383E;
         display: flex;
-        flex-dorection: column;
+        flex-direction: column;
         justify-content: center;
         align-items: center;
         height: 100%;


### PR DESCRIPTION
Tested locally, all fine, the typo made IE 11 break though 👍 